### PR TITLE
Fix #260: Commons BeanUtils2

### DIFF
--- a/core/pom-common.xml
+++ b/core/pom-common.xml
@@ -181,8 +181,8 @@
 			<optional>false</optional>
 		</dependency>
 		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-beanutils2</artifactId>
 			<version>${commons-beanutils.version}</version>
 			<scope>compile</scope>
 			<optional>false</optional>

--- a/core/src/main/java/net/sf/jasperreports/engine/data/JRAbstractBeanDataSource.java
+++ b/core/src/main/java/net/sf/jasperreports/engine/data/JRAbstractBeanDataSource.java
@@ -27,8 +27,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.beanutils.NestedNullException;
-import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.beanutils2.NestedNullException;
+import org.apache.commons.beanutils2.PropertyUtils;
 
 import net.sf.jasperreports.annotations.properties.Property;
 import net.sf.jasperreports.annotations.properties.PropertyScope;

--- a/core/src/main/java/net/sf/jasperreports/engine/data/JRAbstractTextDataSource.java
+++ b/core/src/main/java/net/sf/jasperreports/engine/data/JRAbstractTextDataSource.java
@@ -29,7 +29,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.apache.commons.beanutils.locale.LocaleConvertUtilsBean;
+import org.apache.commons.beanutils2.locale.LocaleConvertUtilsBean;
 
 import net.sf.jasperreports.engine.JRDataSource;
 import net.sf.jasperreports.engine.JRException;

--- a/core/src/main/java/net/sf/jasperreports/engine/util/JRDateLocaleConverter.java
+++ b/core/src/main/java/net/sf/jasperreports/engine/util/JRDateLocaleConverter.java
@@ -26,10 +26,11 @@ package net.sf.jasperreports.engine.util;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.apache.commons.beanutils.locale.converters.DateLocaleConverter;
+import org.apache.commons.beanutils2.locale.converters.DateLocaleConverter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -46,7 +47,7 @@ import org.apache.commons.logging.LogFactory;
  * @author szaharia
  */
 
-public class JRDateLocaleConverter extends DateLocaleConverter 
+public class JRDateLocaleConverter extends DateLocaleConverter<Date> 
 {
 
 	private static Log log = LogFactory.getLog(DateLocaleConverter.class);
@@ -60,18 +61,18 @@ public class JRDateLocaleConverter extends DateLocaleConverter
 	 */
 	public JRDateLocaleConverter(TimeZone timeZone) 
 	{
-		super();
+		super(null, null, null, false, true, true);
 
 		this.timeZone = timeZone;
 	}
 
 	@Override
-	protected Object parse(Object value, String pattern) throws ParseException 
+	protected Date parse(Object value, String pattern) throws ParseException 
 	{
 		SimpleDateFormat formatter = getFormatter(pattern, locale);
 		if (pattern != null)
 		{
-			if (locPattern) {
+			if (localizedPattern) {
 				formatter.applyLocalizedPattern(pattern);
 			}
 			else {
@@ -87,7 +88,7 @@ public class JRDateLocaleConverter extends DateLocaleConverter
 	private SimpleDateFormat getFormatter(String pattern, Locale locale) 
 	{
 		if(pattern == null) {
-			pattern = locPattern ? 
+			pattern = localizedPattern ? 
 				new SimpleDateFormat().toLocalizedPattern() : new SimpleDateFormat().toPattern();
 			log.warn("Null pattern was provided, defaulting to: " + pattern);
 		}

--- a/ext/hibernate-j2ee/pom.xml
+++ b/ext/hibernate-j2ee/pom.xml
@@ -26,13 +26,6 @@
 			<optional>false</optional>
 		</dependency>
 		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
-			<version>${commons-beanutils.version}</version>
-			<scope>compile</scope>
-			<optional>false</optional>
-		</dependency>
-		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports-data-adapters</artifactId>
 			<version>${revision}</version>

--- a/ext/hibernate-j2ee/src/main/java/net/sf/jasperreports/j2ee/hibernate/JRHibernateAbstractDataSource.java
+++ b/ext/hibernate-j2ee/src/main/java/net/sf/jasperreports/j2ee/hibernate/JRHibernateAbstractDataSource.java
@@ -26,7 +26,6 @@ package net.sf.jasperreports.j2ee.hibernate;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.beanutils.PropertyUtils;
 import org.hibernate.type.Type;
 
 import net.sf.jasperreports.engine.JRDataSource;
@@ -159,7 +158,7 @@ public abstract class JRHibernateAbstractDataSource implements JRDataSource
 		else
 		{
 			@SuppressWarnings("deprecation")
-			int firstNestedIdx = fieldMapping.indexOf(PropertyUtils.NESTED_DELIM);
+			int firstNestedIdx = fieldMapping.indexOf(".");
 
 			if (firstNestedIdx >= 0 && aliasesMap.containsKey(fieldMapping.substring(0, firstNestedIdx)))
 			{
@@ -188,7 +187,7 @@ public abstract class JRHibernateAbstractDataSource implements JRDataSource
 		if (fieldIdx == null)
 		{
 			@SuppressWarnings("deprecation")
-			int firstNestedIdx = fieldMapping.indexOf(PropertyUtils.NESTED_DELIM);
+			int firstNestedIdx = fieldMapping.indexOf(".");
 			
 			if (firstNestedIdx < 0)
 			{

--- a/ext/hibernate/pom.xml
+++ b/ext/hibernate/pom.xml
@@ -26,13 +26,6 @@
 			<optional>false</optional>
 		</dependency>
 		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
-			<version>${commons-beanutils.version}</version>
-			<scope>compile</scope>
-			<optional>false</optional>
-		</dependency>
-		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports-data-adapters</artifactId>
 			<version>${revision}</version>

--- a/ext/hibernate/src/main/java/net/sf/jasperreports/hibernate/JRHibernateAbstractDataSource.java
+++ b/ext/hibernate/src/main/java/net/sf/jasperreports/hibernate/JRHibernateAbstractDataSource.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
-import org.apache.commons.beanutils.PropertyUtils;
-
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TupleElement;
 import net.sf.jasperreports.engine.JRDataSource;
@@ -157,7 +155,7 @@ public abstract class JRHibernateAbstractDataSource implements JRDataSource
 		else
 		{
 			@SuppressWarnings("deprecation")
-			int firstNestedIdx = fieldMapping.indexOf(PropertyUtils.NESTED_DELIM);
+			int firstNestedIdx = fieldMapping.indexOf(".");
 
 			if (firstNestedIdx >= 0 && aliasesMap.containsKey(fieldMapping.substring(0, firstNestedIdx)))
 			{
@@ -179,7 +177,7 @@ public abstract class JRHibernateAbstractDataSource implements JRDataSource
 		if (fieldIdx == null)
 		{
 			@SuppressWarnings("deprecation")
-			int firstNestedIdx = fieldMapping.indexOf(PropertyUtils.NESTED_DELIM);
+			int firstNestedIdx = fieldMapping.indexOf(".");
 			
 			if (firstNestedIdx < 0)
 			{

--- a/pom-parent.xml
+++ b/pom-parent.xml
@@ -125,7 +125,7 @@
 		<antlr.version>2.7.7</antlr.version>
 		<batik.version>1.17</batik.version>
 		<castor.version>1.4.1</castor.version>
-		<commons-beanutils.version>2.0.0-M1</commons-beanutils.version>
+		<commons-beanutils.version>2.0.0-M2</commons-beanutils.version>
 		<commons-collections4.version>4.5.0-M3</commons-collections4.version>
 		<commons-logging.version>1.3.0</commons-logging.version>
 		<hsqldb.version>2.7.2</hsqldb.version>

--- a/pom-parent.xml
+++ b/pom-parent.xml
@@ -126,7 +126,7 @@
 		<batik.version>1.17</batik.version>
 		<castor.version>1.4.1</castor.version>
 		<commons-beanutils.version>2.0.0-M2</commons-beanutils.version>
-		<commons-collections4.version>4.5.0-M3</commons-collections4.version>
+		<commons-collections4.version>4.5.0</commons-collections4.version>
 		<commons-logging.version>1.3.0</commons-logging.version>
 		<hsqldb.version>2.7.2</hsqldb.version>
 		<jackson.version>2.17.1</jackson.version>

--- a/pom-parent.xml
+++ b/pom-parent.xml
@@ -125,8 +125,8 @@
 		<antlr.version>2.7.7</antlr.version>
 		<batik.version>1.17</batik.version>
 		<castor.version>1.4.1</castor.version>
-		<commons-beanutils.version>1.9.4</commons-beanutils.version>
-		<commons-collections4.version>4.4</commons-collections4.version>
+		<commons-beanutils.version>2.0.0-M1</commons-beanutils.version>
+		<commons-collections4.version>4.5.0-M3</commons-collections4.version>
 		<commons-logging.version>1.3.0</commons-logging.version>
 		<hsqldb.version>2.7.2</hsqldb.version>
 		<jackson.version>2.17.1</jackson.version>


### PR DESCRIPTION
Fix #260: Commons BeanUtils2

- [x] Removes the CVE on Commons Collections 3.2
- [x] Simplifies by removing this dependency from Hibernate it was being used for 1 single Constant which was deprecated and removed from BeanUtils2
- [x] Allows you to simply change the dependency to Apache Commons BeanUtils2 (if it ever comes out been waiting 5 years)