### PR TITLE
#576 add JRVirtualizationContext to javaflow maven resources

### DIFF
--- a/core/pom-javaflow.xml
+++ b/core/pom-javaflow.xml
@@ -62,6 +62,7 @@
 										<include>net/sf/jasperreports/engine/fill/JRSubreportRunnable.class</include>
 										<include>net/sf/jasperreports/engine/fill/JRContinuationSubreportRunner.class</include>
 										<include>net/sf/jasperreports/engine/fill/FillerSubreportParent.class</include>
+										<include>net/sf/jasperreports/engine/fill/JRVirtualizationContext.class</include>
 										<include>default.jasperreports.properties</include>
 									</includes>
 								</resource>


### PR DESCRIPTION
#576 chore(core): add JRVirtualizationContext to javaflow maven resources

- Add JRVirtualizationContext.class to pom-javaflow.xml resource includes
- Ensures virtualization context class is included in javaflow build artifacts