### PR TITLE
Use finally block to ensure value is reset to null

### DIFF
--- a/ext/excel-poi/src/main/java/net/sf/jasperreports/poi/export/JRXlsExporter.java
+++ b/ext/excel-poi/src/main/java/net/sf/jasperreports/poi/export/JRXlsExporter.java
@@ -656,8 +656,11 @@ public class JRXlsExporter extends JRXlsAbstractExporter<XlsReportConfiguration,
 			{
 				Biff8EncryptionKey.setCurrentUserPassword(encryptionPassword);
 			}
-			workbook.write(os);
-			Biff8EncryptionKey.setCurrentUserPassword(null);
+			try {
+				workbook.write(os);
+			} finally {
+				Biff8EncryptionKey.setCurrentUserPassword(null);
+			}
 		}
 		catch (IOException e)
 		{

--- a/ext/excel-poi/src/main/java/net/sf/jasperreports/poi/export/JRXlsMetadataExporter.java
+++ b/ext/excel-poi/src/main/java/net/sf/jasperreports/poi/export/JRXlsMetadataExporter.java
@@ -580,8 +580,11 @@ public class JRXlsMetadataExporter extends JRXlsAbstractMetadataExporter<XlsMeta
 			{
 				Biff8EncryptionKey.setCurrentUserPassword(encryptionPassword);
 			}
-			workbook.write(os);
-			Biff8EncryptionKey.setCurrentUserPassword(null);
+			try {
+			    workbook.write(os);
+			} finally {
+			    Biff8EncryptionKey.setCurrentUserPassword(null);
+			}
 			
 		} catch (IOException e) {
 			throw 

--- a/ext/excel-poi/src/main/java/net/sf/jasperreports/poi/export/JRXlsMetadataExporter.java
+++ b/ext/excel-poi/src/main/java/net/sf/jasperreports/poi/export/JRXlsMetadataExporter.java
@@ -581,9 +581,9 @@ public class JRXlsMetadataExporter extends JRXlsAbstractMetadataExporter<XlsMeta
 				Biff8EncryptionKey.setCurrentUserPassword(encryptionPassword);
 			}
 			try {
-			    workbook.write(os);
+				workbook.write(os);
 			} finally {
-			    Biff8EncryptionKey.setCurrentUserPassword(null);
+				Biff8EncryptionKey.setCurrentUserPassword(null);
 			}
 			
 		} catch (IOException e) {


### PR DESCRIPTION
POI write calls can fail and it is best to ensure that Biff8EncryptionKey is reset even in failure cases.